### PR TITLE
Removed restricting assert

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -700,7 +700,6 @@ class scheme_graph:
             if self.enable_or:
                 enabled_gates.append('OR')
             if self.enable_maj and len(n.fanin_options) > 2:
-                assert(self.nr_pis > 2)
                 enabled_gates.append('MAJ')
             if self.enable_crossings:
                 if ((not n.is_border_node and (len(n.virtual_fanin) == 2)) or


### PR DESCRIPTION
The `assert` statement in line 703 is overly restrictive. Even 2-input functions can utilize MAJ meaningfully because of fan-outs.