### PR TITLE
Possible error in exception formatting

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -431,7 +431,7 @@ class logic_network:
                 else:
                     sim_vals[n][out_dir] = sim_vals[n.fanin[OPPOSITE_DIRECTION[out_dir]]][out_dir]
             else:
-                raise SynthesisException("Uknown gate type '{}' in simulation".format(gate_type))
+                raise SynthesisException("Uknown gate type '{}' in simulation".format(n.gate_type))
 
     def simulate(self):
         '''


### PR DESCRIPTION
I might be wrong here, but to me, it looks like `gate_type` is an attribute of `n`. Therefore, this line of code might crash on execution.